### PR TITLE
Fix typos in united nations ids

### DIFF
--- a/spyfall/i18n/en.i18n.json
+++ b/spyfall/i18n/en.i18n.json
@@ -438,13 +438,13 @@
             "the united nations": {
                 "diplomat": "Diplomat",
                 "interpreter": "Interpreter",
-                "bloward": "Blowhard",
+                "blowhard": "Blowhard",
                 "tourist": "Tourist",
                 "napping delegate": "Napping Delegate",
                 "journalist": "Journalist",
                 "secretary of state": "Secretary of State",
                 "speaker": "Speaker",
-                "secretary general": "Secretary General",
+                "secretary-general": "Secretary General",
                 "lobbyist": "Lobbyist"
             },
             "candy factory": {


### PR DESCRIPTION
For reference: https://github.com/mpcovcd/spyfall/blob/475df8c53bc7c187126172802b61ecdb9875e860/spyfall/lib/locations2.js#L147-L153