### PR TITLE
Fixed kicking issue #39

### DIFF
--- a/spyfall/client/main.js
+++ b/spyfall/client/main.js
@@ -453,6 +453,7 @@ Template.lobby.events({
   'click .btn-remove-player': function (event) {
     var playerID = $(event.currentTarget).data('player-id');
     Players.remove(playerID);
+    return false;
   },
   'click .btn-edit-player': function (event) {
     var game = getCurrentGame();


### PR DESCRIPTION
When player are trying to remove another player, he will be redirected to route:
https://github.com/mpcovcd/spyfall/blob/c1f09b81998b4f2b2796a5dd7a17fe47fec3415d/spyfall/lib/routes.js#L6-L10
which will trigger settting ```currentViewe``` to ```joinGame``` instead of ```lobby```.
Returning ```false``` in remove event will prevent Meteor to reload page and going into the ```joinGame``` view.