### PR TITLE
Add german translation for cemetery

### DIFF
--- a/spyfall/i18n/de.i18n.json
+++ b/spyfall/i18n/de.i18n.json
@@ -111,6 +111,18 @@
                 "chorister": "Chorsänger",
                 "parishioner": "Mitglied der Kirchengemeinde"
             },
+            "cemetery": {
+                "priest": "Priester",
+                "grave robber": "Grabräuber",
+                "poet": "Poet",
+                "mourning person": "Trauernde Person",
+                "gatekeeper": "Torwächter",
+                "dead person": "Tote Person",
+                "relative": "Angehöriger",
+                "flower seller": "Blumenverkäufer",
+                "grave digger": "Totengräber",
+                "gothic girl": "Gothic Girl"
+            },
             "circus tent": {
                 "acrobat": "Akrobat",
                 "animal trainer": "Dompteur",


### PR DESCRIPTION
Somehow the cemetery is the only location that has no german roles yet.