### PR TITLE
Use monospace font for countdown

### DIFF
--- a/spyfall/client/css/styles.less
+++ b/spyfall/client/css/styles.less
@@ -245,6 +245,7 @@ a {
 .game-countdown {
     color: #333;
     text-decoration: none;
+    font-family: "Liberation Mono", monospace;
 
     &:active, &:focus, &:hover {
         color: #333;


### PR DESCRIPTION
The countdown did move by a few pixels every second depending on it's current width. This can be fixed by using a monospave font.